### PR TITLE
chore: Add mypy type-check CI job and complete type stubs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,6 +31,20 @@ jobs:
       - name: Run Ruff format
         run: ruff format python/ --check
 
+  type-check:
+    name: Type Check
+    needs: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: pip install mypy pyarrow
+      - name: Run mypy
+        run: mypy
+
   test:
     name: Test
     needs: lint # Only run tests if linting passes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,14 @@ requires-python = ">=3.10"
 python-source = "python"
 module-name = "xml2arrow._xml2arrow"
 
+[tool.mypy]
+strict = true
+files = ["python/xml2arrow"]
+
+[[tool.mypy.overrides]]
+module = ["pyarrow", "pyarrow.*"]
+ignore_missing_imports = true
+
 [tool.ruff]
 # Target the minimum Python version supported by your project
 target-version = "py310"

--- a/python/xml2arrow/_xml2arrow.pyi
+++ b/python/xml2arrow/_xml2arrow.pyi
@@ -1,8 +1,9 @@
 from os import PathLike
-from typing import IO, Any
+from typing import IO, Any, final
 
 from pyarrow import RecordBatch
 
+@final
 class XmlToArrowParser:
     """A parser for converting XML files to Arrow tables based on a configuration.
 
@@ -13,7 +14,7 @@ class XmlToArrowParser:
             base exception.
     """
 
-    def __init__(self, config_path: str | PathLike) -> None:
+    def __init__(self, config_path: str | PathLike[str]) -> None:
         """Initializes the parser with a configuration file path.
 
         Args:
@@ -25,7 +26,7 @@ class XmlToArrowParser:
 
     def parse(
         self,
-        source: str | PathLike | bytes | bytearray | IO[Any],
+        source: str | PathLike[str] | bytes | bytearray | IO[Any],
     ) -> dict[str, RecordBatch]:
         """Parses an XML source and returns a dictionary of Arrow RecordBatches.
 
@@ -48,6 +49,13 @@ class XmlToArrowParser:
         """
 
     def __repr__(self) -> str: ...
+
+class Xml2ArrowError(Exception): ...
+class XmlParsingError(Xml2ArrowError): ...
+class YamlParsingError(Xml2ArrowError): ...
+class ParseError(Xml2ArrowError): ...
+class UnsupportedConversionError(Xml2ArrowError): ...
+class InvalidConfigError(Xml2ArrowError): ...
 
 def _get_version() -> str:
     """Returns the version of the xml2arrow package."""


### PR DESCRIPTION
Declare the exception hierarchy in the .pyi stub so downstream code that imports from xml2arrow.exceptions type-checks cleanly. Mark XmlToArrowParser @final (the pyclass cannot be meaningfully subclassed) and tighten PathLike -> PathLike[str] per PEP 519.

Configure mypy --strict in pyproject.toml and wire a type-check job into CI so stub/Rust drift is caught automatically.